### PR TITLE
Disable prepared_statements and advisory_locks for production due to Supabase transaction pooling

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -72,6 +72,8 @@ production:
   primary: &primary_production
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+    prepared_statements: false
+    advisory_locks: false
 
   cache:
     <<: *primary_production


### PR DESCRIPTION
Supabase uses PgBouncer in transaction pooling mode, which is incompatible with ActiveRecord’s default usage of prepared statements and advisory locks.

Setting prepared_statements: false and advisory_locks: false in config/database.yml for production avoids errors like:
```pgsql
PG::DuplicatePstatement: ERROR: prepared statement "a1" already exists
```
More info: https://edgeguides.rubyonrails.org/configuring.html#configuring-a-postgresql-database


